### PR TITLE
Fixed missing argument pass-through

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -416,7 +416,7 @@ def download(url, args, stop_event=None):
                         if i1 > i0:
                             url = script.string[i0 + L:i1]
                             print(f"[*] Detected redirect to: {url}")
-                            return download(url)
+                            return download(url, args)
 
         # Try multiple methods to find the title
         name = None
@@ -767,7 +767,7 @@ def download(url, args, stop_event=None):
                                 "/") else base_url + "/" + iframe_src
 
                         print(f"[*] Found iframe, following to: {iframe_src}")
-                        return download(iframe_src)
+                        return download(iframe_src, args)
 
         if not source_json:
             print("[!] Could not find sources in the page. The site structure might have changed.")


### PR DESCRIPTION
Hey, I have noticed the following error, that sometimes occurs because there is a missing pass-through for `args`. 

The error message is:
```
[!] Unexpected error: download() missing 1 required positional argument: 'args'
```

As you can see in the diff, just a small change is required. Tested it and is working again.
Would appreciate, If you'd merge the PR soon.